### PR TITLE
Boilerplate documentation sections support

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,14 @@ generated API documentation goes here
 
 The [default HTML outer document](internal/doc/outer.html) is a good starting point for creating your own HTML outer document.
 
+Documentation for extensions usually includes common sections. For example, how to build k6 with the extension, or download pre-built k6 binaries, etc.
+
+For different extensions, these boilerplate documentation sections differ almost only in the extension name and the repository URL. Consequently, these sections can be easily generated.
+
+The [`doc`](#tygor-doc) subcommand can generate these boilerplate sections if the necessary parameters (eg repository name) are specified or detected. Thus, the extension developer does not have to write these sections, and if the tooling changes (e.g. the xk6 tool changes or improves), they are simply re-generable.
+
+By default, GitHub repository and generateable boilerplate sections are automatically detected. This is done by examining the git configuration, the GitHub workflows configuration, and the examples directory.
+
 **parse**
 
 The [`parse`](#tygor-parse) subcommand simply displays (or writes to a file) the API model in JSON format. With its use, the API model can be processed by external programs without the complexity of TypeScript parsing.
@@ -527,6 +535,9 @@ API documentation can also be inserted (and updated) into an existing Markdown o
 
 The generated API documentation starts at heading level 1 by default. The starting heading level can be specified by using the --heading flag, which can be useful, for example, when inserting into an outer document.
 
+The documentation may include the usual extension documentation sections, such as build instructions, download instructions, a link to the examples folder, etc. The required GitHub repository can be specified using the --github-repo flag. Otherwise, the tygor doc subcommand tries to guess the GitHub repository from the git configuration (if it exists). This automation can be disabled with the --no-auto flag.
+By default, GitHub repository and generateable boilerplate sections are automatically detected. This is done by examining the git configuration, the GitHub workflows configuration, and the examples directory.
+
 The only mandatory argument to the doc subcommand is the name of the declaration file (which file name must end with a .d.ts suffix).
 
 
@@ -543,12 +554,17 @@ $ tygor doc -o README.md hitchhiker.d.ts
 ### Options
 
 ```
-      --heading uint      initial heading level (default 1)
-  -h, --help              help for doc
-      --html              enable HTML output (default: based on file ext)
-  -i, --inject string     inject into outer file
-  -o, --output string     output file (default: standard output)
-  -t, --template string   go template file for markdown generation
+      --github-repo string   GitHub repository (owner/name)
+      --heading uint         initial heading level (default 1)
+  -h, --help                 help for doc
+      --html                 enable HTML output (default: based on file ext)
+  -i, --inject string        inject into outer file
+      --link-examples        enable examples folder link
+      --link-packages        enable GitHub container packages link
+      --link-releases        enable GitHub releases link
+      --no-auto              disable automatic GitHub repo and link flags detection
+  -o, --output string        output file (default: standard output)
+  -t, --template string      go template file for markdown generation
 ```
 
 ### SEE ALSO

--- a/examples/faker/README.md
+++ b/examples/faker/README.md
@@ -3,6 +3,9 @@ k6/x/faker
 
 xk6-faker random fake data generator
 
+API
+===
+
 Faker
 -----
 

--- a/examples/faker/index.html
+++ b/examples/faker/index.html
@@ -46,6 +46,8 @@
 
 <p>xk6-faker random fake data generator</p>
 
+<h1 id="api">API</h1>
+
 <h2 id="faker">Faker</h2>
 
 <p>This is Faker's main class containing all modules that can be used to generate data.</p>

--- a/examples/hitchhiker/README.md
+++ b/examples/hitchhiker/README.md
@@ -1,6 +1,9 @@
 k6/x/hitchhiker
 ===============
 
+API
+===
+
 Guide
 -----
 

--- a/examples/hitchhiker/index.html
+++ b/examples/hitchhiker/index.html
@@ -44,6 +44,8 @@
 <!-- begin:api -->
 <h1 id="k6-x-hitchhiker">k6/x/hitchhiker</h1>
 
+<h1 id="api">API</h1>
+
 <h2 id="guide">Guide</h2>
 
 <h3 id="guide-1">Guide()</h3>

--- a/examples/state/README.md
+++ b/examples/state/README.md
@@ -1,6 +1,9 @@
 k6/x/state
 ==========
 
+API
+===
+
 ### activeVUs
 
 ```ts

--- a/examples/state/index.html
+++ b/examples/state/index.html
@@ -44,6 +44,8 @@
 <!-- begin:api -->
 <h1 id="k6-x-state">k6/x/state</h1>
 
+<h1 id="api">API</h1>
+
 <h3 id="activevus">activeVUs</h3>
 
 <pre><code class="language-ts">export declare var activeVUs: int64;

--- a/examples/toml/README.md
+++ b/examples/toml/README.md
@@ -10,6 +10,9 @@ Import an entire module's contents: `JavaScript import * as TOML from "k6/x/toml
 
 Import a single export from a module: `JavaScript import { parse } from "k6/x/toml";`
 
+API
+===
+
 ### parse()
 
 ```ts

--- a/examples/toml/index.html
+++ b/examples/toml/index.html
@@ -52,6 +52,8 @@
 
 <p>Import a single export from a module: <code>JavaScript import { parse } from &quot;k6/x/toml&quot;;</code></p>
 
+<h1 id="api">API</h1>
+
 <h3 id="parse">parse()</h3>
 
 <pre><code class="language-ts">export declare function parse(text: string): object;

--- a/internal/cmd/doc.go
+++ b/internal/cmd/doc.go
@@ -204,7 +204,7 @@ func docRun(src string, flags *docFlags) error {
 
 		opts = append(opts, doc.WithOuter(outer))
 
-		file, err = os.OpenFile(flags.outer, os.O_RDWR, 0o600)
+		file, err = os.OpenFile(flags.outer, os.O_RDWR|os.O_TRUNC, 0o600)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/testdata/doc.txt
+++ b/internal/cmd/testdata/doc.txt
@@ -5,8 +5,13 @@ Examples:
 $ tygor doc -o README.md hitchhiker.d.ts
 
 Flags:
-      --heading uint      initial heading level (default 1)
-      --html              enable HTML output (default: based on file ext)
-  -i, --inject string     inject into outer file
-  -o, --output string     output file (default: standard output)
-  -t, --template string   go template file for markdown generation
+      --github-repo string   GitHub repository (owner/name)
+      --heading uint         initial heading level (default 1)
+      --html                 enable HTML output (default: based on file ext)
+  -i, --inject string        inject into outer file
+      --link-examples        enable examples folder link
+      --link-packages        enable GitHub container packages link
+      --link-releases        enable GitHub releases link
+      --no-auto              disable automatic GitHub repo and link flags detection
+  -o, --output string        output file (default: standard output)
+  -t, --template string      go template file for markdown generation

--- a/internal/doc/doc.gtpl
+++ b/internal/doc/doc.gtpl
@@ -1,6 +1,16 @@
-{{ h 1 }} k6/x/{{ .Name }}
+{{- $title := list "k6/x" .Name | join "/" -}}
+{{- if .GitHub.Repo -}}
+{{- $title = .GitHub.RepoName -}}
+{{- end -}}
+
+{{ h 1 }} {{ $title }}
 
 {{ doc .Namespace }}
+{{ template "example" example .Namespace }}
+
+{{ template "github_related" . }}
+
+{{ h 1 }} API
 
 {{- /* classes and interfaces */ -}}
 {{ range $parent := (concat .Classes .Interfaces) }}
@@ -99,6 +109,39 @@
 {{    template "source" .Source}}
 {{    doc . }}
 {{    template "example" example . }}
+{{   end }}
+{{- end -}}
+{{- /* title */ -}}
+{{- define "github_related" -}}
+{{  if .GitHub.Repo }}
+{{   if .GitHub.Examples }}
+The [examples](https://github.com/{{.GitHub.Repo}}/blob/master/examples) directory contains examples of how to use the {{.GitHub.RepoName}} extension.
+A k6 binary containing the {{.GitHub.RepoName}} extension is required to run the examples.
+*If the search path also contains the k6 command, don't forget to specify which k6 you want to run (for example `./k6`)*.
+{{   end }}
+{{   if or .GitHub.Releases .GitHub.Packages }}
+**Download**
+
+{{     if .GitHub.Releases -}}
+You can download pre-built k6 binaries from the [Releases](https://github.com/{{.GitHub.Repo}}/releases/) page.
+{{-     end }}{{     if .GitHub.Packages }}
+ Check the [Packages](https://github.com/{{.GitHub.Repo}}/pkgs/container/{{.GitHub.RepoName}}) page for pre-built k6 Docker images.
+{{-     end -}}
+{{   end }}
+
+<details>
+<summary><strong>Build</strong></summary>
+
+The [xk6](https://github.com/grafana/xk6) build tool can be used to build a k6 that will include {{.GitHub.RepoName}} extension:
+
+```bash
+$ xk6 build --with github.com/{{.GitHub.Repo}}@latest
+```
+
+For more build options and how to use xk6, check out the [xk6 documentation]([xk6](https://github.com/grafana/xk6)).
+
+</details>
+
 {{   end }}
 {{- end -}}
 {{- /*--------------- template definitions ---------------*/ -}}

--- a/internal/doc/options.go
+++ b/internal/doc/options.go
@@ -12,6 +12,11 @@ type options struct {
 	templateName string
 	outer        []byte
 	heading      uint
+
+	githubRepo   string
+	linkReleases bool
+	linkPackages bool
+	linkExamples bool
 }
 
 // Option defines a documentation generator option function.
@@ -49,6 +54,34 @@ func WithOuter(outer []byte) Option {
 func WithHeading(heading uint) Option {
 	return func(o *options) {
 		o.heading = heading
+	}
+}
+
+// WithGitHubRepo can be used to specify the GitHub repository in owner/name form.
+func WithGitHubRepo(repo string) Option {
+	return func(o *options) {
+		o.githubRepo = repo
+	}
+}
+
+// WithLinkReleases can be used to enable/disable GitHub releases link.
+func WithLinkReleases(flag bool) Option {
+	return func(o *options) {
+		o.linkReleases = flag
+	}
+}
+
+// WithLinkPackages can be used to enable/disable GitHub container packages link.
+func WithLinkPackages(flag bool) Option {
+	return func(o *options) {
+		o.linkPackages = flag
+	}
+}
+
+// WithLinkExamples can be used to enable/disable examples folder link.
+func WithLinkExamples(flag bool) Option {
+	return func(o *options) {
+		o.linkExamples = flag
 	}
 }
 

--- a/releases/v0.1.2.md
+++ b/releases/v0.1.2.md
@@ -1,0 +1,11 @@
+tygor `v0.1.2` is here 🎉!
+
+This is a patch release, it contains documentation generation improvements.
+
+Documentation for extensions usually includes common sections. For example, how to build k6 with the extension, or download pre-built k6 binaries, etc.
+
+For different extensions, these boilerplate documentation sections differ almost only in the extension name and the repository URL. Consequently, these sections can be easily generated.
+
+The `tygor doc` command can generate these boilerplate sections if the necessary parameters (eg repository name) are specified or detected. Thus, the extension developer does not have to write these sections, and if the tooling changes (e.g. the xk6 tool changes or improves), they are simply re-generable.
+
+By default, GitHub repository and generateable boilerplate sections are automatically detected. This is done by examining the git configuration, the GitHub workflows configuration, and the examples directory.


### PR DESCRIPTION
This is a patch release, it contains documentation generation improvements.

Documentation for extensions usually includes common sections. For example, how to build k6 with the extension, or download pre-built k6 binaries, etc.

For different extensions, these boilerplate documentation sections differ almost only in the extension name and the repository URL. Consequently, these sections can be easily generated.

The `tygor doc` command can generate these boilerplate sections if the necessary parameters (eg repository name) are specified or detected. Thus, the extension developer does not have to write these sections, and if the tooling changes (e.g. the xk6 tool changes or improves), they are simply re-generable.

By default, GitHub repository and generateable boilerplate sections are automatically detected. This is done by examining the git configuration, the GitHub workflows configuration, and the examples directory.
